### PR TITLE
update ivi_xmit.c (interface id padding)

### DIFF
--- a/control
+++ b/control
@@ -2,8 +2,8 @@
 
 start() {
 	if [ ! -f modules/ivi.ko ] ; then
-		echo "Error: please make modules first."
-		exit 1
+		make -C modules
+		make -C utils
 	fi
 	if ( lsmod | grep "ivi" ) ; then
 		echo "Error: modules exist, run 'control restart' instead."

--- a/modules/ivi_xmit.c
+++ b/modules/ivi_xmit.c
@@ -163,18 +163,19 @@ static int ipaddr_4to6(unsigned int *v4addr, u16 port, u8 _dir, struct in6_addr 
 
 	if (fmt == ADDR_FMT_MAPT) {
 		if ((prefixlen << 3) + ealen <= 64) {
-  			o = 24 + remainder; // initial offset for the first uncompleted byte
-  			for (i = prefixlen; i < 8; i++) { // eabits outside /64 are cutted
- 				v6addr->s6_addr[i] += (unsigned char)((eabits >> o) & 0xff);
- 				o -= 8;
-  			}
-  			v6addr->s6_addr[8] = 0x00;
-			v6addr->s6_addr[9] = (unsigned char)(addr >> 24);
-			v6addr->s6_addr[10] = (unsigned char)((addr >> 16) & 0xff);
-			v6addr->s6_addr[11] = (unsigned char)((addr >> 8) & 0xff);
-			v6addr->s6_addr[12] = (unsigned char)(addr & 0xff);
-			v6addr->s6_addr[13] = (suffix >> 8) & 0xff;
-			v6addr->s6_addr[14] = suffix & 0xff;
+			o = 24 + remainder; // initial offset for the first uncompleted byte
+			for (i = prefixlen; i < 8; i++) { // eabits outside /64 are cutted
+				v6addr->s6_addr[i] += (unsigned char)((eabits >> o) & 0xff);
+				o -= 8;
+			}
+			v6addr->s6_addr[8] = 0x00;
+			v6addr->s6_addr[9] = 0x00;
+			v6addr->s6_addr[10] = (unsigned char)(addr >> 24);
+			v6addr->s6_addr[11] = (unsigned char)((addr >> 16) & 0xff);
+			v6addr->s6_addr[12] = (unsigned char)((addr >> 8) & 0xff);
+			v6addr->s6_addr[13] = (unsigned char)(addr & 0xff);
+			v6addr->s6_addr[14] = (suffix >> 8) & 0xff;
+			v6addr->s6_addr[15] = suffix & 0xff;
 		} else {
 #ifdef IVI_DEBUG_RULE
 			printk(KERN_DEBUG "ipaddr_4to6: cannot map v4 addr " NIP4_FMT \
@@ -184,18 +185,18 @@ static int ipaddr_4to6(unsigned int *v4addr, u16 port, u8 _dir, struct in6_addr 
 		}
 	} else if (fmt == ADDR_FMT_MAPX_CPE) {
 		// this format has no eabits
-		v6addr->s6_addr[9] = (unsigned char)(addr >> 24);
-		v6addr->s6_addr[10] = (unsigned char)((addr >> 16) & 0xff);
-		v6addr->s6_addr[11] = (unsigned char)((addr >> 8) & 0xff);
-		v6addr->s6_addr[12] = (unsigned char)(addr & 0xff);
-		v6addr->s6_addr[13] = (suffix >> 8) & 0xff;
-		v6addr->s6_addr[14] = suffix & 0xff;
+		v6addr->s6_addr[10] = (unsigned char)(addr >> 24);
+		v6addr->s6_addr[11] = (unsigned char)((addr >> 16) & 0xff);
+		v6addr->s6_addr[12] = (unsigned char)((addr >> 8) & 0xff);
+		v6addr->s6_addr[13] = (unsigned char)(addr & 0xff);
+		v6addr->s6_addr[14] = (suffix >> 8) & 0xff;
+		v6addr->s6_addr[15] = suffix & 0xff;
 	} else {
 		// DMR translation: just copy the addr
-		v6addr->s6_addr[9] = (unsigned char)(addr >> 24);
-		v6addr->s6_addr[10] = (unsigned char)((addr >> 16) & 0xff);
-		v6addr->s6_addr[11] = (unsigned char)((addr >> 8) & 0xff);
-		v6addr->s6_addr[12] = (unsigned char)(addr & 0xff);
+		v6addr->s6_addr[10] = (unsigned char)(addr >> 24);
+		v6addr->s6_addr[11] = (unsigned char)((addr >> 16) & 0xff);
+		v6addr->s6_addr[12] = (unsigned char)((addr >> 8) & 0xff);
+		v6addr->s6_addr[13] = (unsigned char)(addr & 0xff);
 	}
 
 	return 0;
@@ -226,10 +227,10 @@ static int ipaddr_6to4(struct in6_addr *v6addr, u8 _dir, unsigned int *v4addr, u
 		return -1;
 	}
 	
-	addr |= ((unsigned int)v6addr->s6_addr[9]) << 24;
-	addr |= ((unsigned int)v6addr->s6_addr[10]) << 16;
-	addr |= ((unsigned int)v6addr->s6_addr[11]) << 8;
-	addr |= ((unsigned int)v6addr->s6_addr[12]);
+	addr |= ((unsigned int)v6addr->s6_addr[10]) << 24;
+	addr |= ((unsigned int)v6addr->s6_addr[11]) << 16;
+	addr |= ((unsigned int)v6addr->s6_addr[12]) << 8;
+	addr |= ((unsigned int)v6addr->s6_addr[13]);
 	*v4addr = htonl(addr);
 
 	if (_dir == ADDR_DIR_DST) {		
@@ -260,7 +261,7 @@ static int ipaddr_6to4(struct in6_addr *v6addr, u8 _dir, unsigned int *v4addr, u
 
 		/* offset is obtained from Interface Identifier */	
 		if (fmt == ADDR_FMT_MAPT)
-			*offset = (v6addr->s6_addr[13] << 8) + v6addr->s6_addr[14];
+			*offset = (v6addr->s6_addr[14] << 8) + v6addr->s6_addr[15];
 		else if (fmt == ADDR_FMT_NONE)
 			*offset = 0;
 	}


### PR DESCRIPTION
As per the latest revision of the "Mapping of Address and Port using
Translation (MAP-T)"(draft-ietf-softwire-map-t-04):

5.5. The IPv6 Interface Identifier
   The Interface identifier format of a MAP node is described below.

   |        128-n-o-s bits            |
   | 16 bits|    32 bits     | 16 bits|
   +--------+----------------+--------+
   |   0    |  IPv4 address  |  PSID  |
   +--------+----------------+--------+
                 Figure 8

   In the case of an IPv4 prefix, the IPv4 address field is right-padded
   with zeros up to 32 bits.  The k-bit PSID is zero left-padded to
   create a 16 bit field.  For an IPv4 prefix or a complete IPv4
   address, the PSID field is zero.

   If the End-user IPv6 prefix length is larger than 64, the most
   significant parts of the interface identifier is overwritten by the
   prefix.

[https://tools.ietf.org/html/draft-ietf-softwire-map-10#page-13]
[http://tools.ietf.org/html/draft-ietf-softwire-map-t-04#page-15]

The current version of the tool apparently is using the older revision
of the RFC, which specifies the 8bit padding so the current patch fixes it.

After the patch:

$ utils/ivictl -r -d -P 2001:da8:b001:ffff::/64 -T
$ utils/ivictl -s -i eth1 -I eth2 -H -a 202.38.102.130/28 -P 2001:da8:b001::/48 -z 6 -R 16 -o 15 -c 1400 -T

11:27:21.057602 IP 10.0.0.30.47797 > 192.168.45.1.80: Flags [S], seq 2167760328, win 14600, options [mss 1460,sackOK,TS val 4147565200 ecr 0,nop,wscale 6], length 0
11:27:21.057644 IP6 2001:da8:b001:ef00:0:a00:1e:f.1987 > 2001:da8:b001:ffff:0:c0a8:2d01:0.80: Flags [S], seq 2167760328, win 14600, options [mss 1400,sackOK,TS val 4147565200 ecr 0,nop,wscale 6], length 0
